### PR TITLE
Static closure should not use $this

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -28,7 +28,7 @@ final class Query
 
     public function transactional(string $table, array $dataset, array $types = []): int
     {
-        return $this->connection->transactional(static function () use ($table, $dataset, $types): int {
+        return $this->connection->transactional(function () use ($table, $dataset, $types): int {
             return $this->execute($table, $dataset, $types);
         });
     }


### PR DESCRIPTION
`$this` can not be used in static closures. Therefore the `static` keyword should be removed.