### PR TITLE
Class Query should not be final

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -6,7 +6,7 @@ namespace Franzose\DoctrineBulkInsert;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Identifier;
 
-final class Query
+class Query
 {
     private $connection;
 


### PR DESCRIPTION
We use your nice little package in our project. We added it to our Dependency Injection container as a service.

Unfortunately the class `Query` is final. Therefore we can't create mocks with PPHUnit for it and therefore can't unit test classes that depend on this service.

Example:
```php
<?php
namespace Pickware\PickwareErpStarter\ImportExport\Csv;

use Franzose\DoctrineBulkInsert\Query;
use PHPUnit\Framework\TestCase;

class CsvToDatabaseReaderTest extends TestCase
{
    /**
     * @before
     */
    public function setUpTest()
    {
        $this->bulkInserterMock = $this->createMock(Query::class);
        $this->csvToDatabaseReader = new CsvToDatabaseReader($this->bulkInserterMock);
    }

    public function test_readChunk()
    {
        $this->csvToDatabaseReader->readChunk();
    }
}
```

Leads to:
```
Class "Franzose\DoctrineBulkInsert\Query" is declared "final" and cannot be mocked.
.../vendor/phpunit/phpunit/src/TextUI/Command.php:204
.../vendor/phpunit/phpunit/src/TextUI/Command.php:163
```

Also I think there is no reason, this should be final.